### PR TITLE
fix-cloudinary-image-upload

### DIFF
--- a/src/routes/eventRoutes.js
+++ b/src/routes/eventRoutes.js
@@ -13,6 +13,7 @@ router.post(
   authorizeRoles([ROLES.ORGANIZER]),
   verifyRoleInDB([ROLES.ORGANIZER]),
   upload,
+  uploadToCloudinary,
   eventController.createEvent
 );
 router.get(


### PR DESCRIPTION
Long story short: I have been working on uploading the event banner image to Cloudinary. For the last two days, I was stuck trying to fix the event banner issue. After two days of debugging, I realized that the problem wasn’t with the frontend code, we had missed setting uploadToCloudinary in the eventRoutes.js file in the post method.

I’m still curious about why the same code works from Swagger but not from the front-end UI.